### PR TITLE
Update store.js to be more straightforward

### DIFF
--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,5 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit'
 
 export default configureStore({
-  reducer: () => ({}),
+  reducer: {},
 })


### PR DESCRIPTION
i found this confusing : at first i added the postsReducer in the empty dictionary and it didn't work.
so why not have a legit empty dictionary instead of having to remove the dummy function ?